### PR TITLE
:rocket: introduced browserManager object to control all launched b…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 :beetle: - bugfix
 :x: - deprecation
 
+## [0.41.0]
+- :rocket: introduced browserManager object to control all launched browser and electron instances
+- :rocket: added steps to start/stop/switch to other browser/electron instances
+
 ## [0.40.0]
 - :rocket: changed simple expects to poll expects
 - :rocket: changed behavior of _I switch to {string} window_ step (now it is wait for window existence)

--- a/README.md
+++ b/README.md
@@ -35,21 +35,25 @@ module.exports = {
 ## Global variables
 @qavajs/steps-playwright exposes following global variables
          
-| variable   | type                                        | description                                  |
-|------------|---------------------------------------------|----------------------------------------------|
-| `browser`  | `Browser`                                   | browser instance                             |
-| `driver`   | `Browser`                                   | browser instance (alias for browser)         |
-| `context`  | `BrowserContext`                            | current browser context                      |
-| `page`     | `Page`                                      | current context page                         |
-| `contexts` | `{ [contextName: string]: BrowserContext }` | Map of opened contexts in multi browser mode |
+| variable         | type                             | description                                                   |
+|------------------|----------------------------------|---------------------------------------------------------------|
+| `browser`        | `Browser \| ElectronApplication` | browser instance                                              |
+| `driver`         | `Browser \| ElectronApplication` | browser instance (alias for browser)                          |
+| `context`        | `BrowserContext`                 | current browser context                                       |
+| `page`           | `Page`                           | current context page                                          |
+| `browserManager` | `BrowserManager`                 | manager to control all opened browsers and electron instances |
 
 ## Connect to playwright server
 In order to connect to playwright server pass _wsEndpoint_ property in capabilities object
 ```typescript
-{
-    capabilities: {
-        browserName: 'chromium',
-        wsEndpoint: 'ws://127.0.0.1:60291/2bd48ce272de2b543e4c8c533f664b83'    
+module.exports = {
+    default: {
+        browser: {
+            capabilities: {
+                browserName: 'chromium',
+                wsEndpoint: 'ws://127.0.0.1:60291/2bd48ce272de2b543e4c8c533f664b83'
+            }
+        },
     }
 }
 ```
@@ -57,10 +61,14 @@ In order to connect to playwright server pass _wsEndpoint_ property in capabilit
 ## Connect to cdp endpoint
 In order to connect to CDP endpoint pass _cdpEndpoint_ property in capabilities object 
 ```typescript
-{
-    capabilities: {
-        browserName: 'chromium',
-        cdpEndpoint: 'http://localhost:9222/'    
+module.exports = {
+    default: {
+        browser: {
+            capabilities: {
+                browserName: 'chromium',
+                cdpEndpoint: 'http://localhost:9222/'
+            }
+        },
     }
 }
 ```
@@ -127,4 +135,23 @@ To properly use globals exposed by @qavajs/steps-playwright add corresponding ty
   }
 }
 ```
+
+## Development and testing
+Install dependencies
+`npm install`
+
+Install playwright browsers
+`install:browsers`
+
+Build lib
+`npm run build`
+
+Execute unit test (with vitest)
+`npm run test`
+
+Execute e2e browser tests
+`npm run test:e2e`
+
+Execute e2e electron tests
+`npm run test:e2e:electron`
 

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,11 +1,10 @@
 import { Browser, BrowserContext, Page } from 'playwright';
+import { BrowserManager } from './src/browserManager';
 
 declare global {
     var browser: Browser;
     var driver: Browser;
     var context: BrowserContext;
     var page: Page;
-    var contexts: {
-        [contextName: string]: BrowserContext
-    };
+    var browserManager: BrowserManager
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@qavajs/steps-playwright",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@qavajs/steps-playwright",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "^1.40.0",
+        "@playwright/test": "^1.40.1",
         "@qavajs/validation": "^0.7.0",
-        "playwright": "^1.40.0"
+        "playwright": "^1.40.1"
       },
       "devDependencies": {
         "@cucumber/cucumber": "^10.0.1",
-        "@qavajs/cli": "^0.32.0",
+        "@qavajs/cli": "^0.32.1",
         "@qavajs/console-formatter": "^0.6.0",
         "@qavajs/html-formatter": "^0.15.2",
         "@qavajs/memory": "^1.6.2",
@@ -24,6 +24,7 @@
         "@types/chai": "^4.3.11",
         "@types/express": "^4.17.21",
         "@vitest/coverage-v8": "^0.34.6",
+        "@vitest/ui": "^0.34.6",
         "electron": "^27.1.2",
         "express": "^4.18.2",
         "ts-node": "^10.9.1",
@@ -1110,6 +1111,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1121,11 +1157,11 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.0.tgz",
-      "integrity": "sha512-PdW+kn4eV99iP5gxWNSDQCbhMaDVej+RXL5xr6t04nbKLCBwYtA046t7ofoczHOm8u6c+45hpDKQVZqtqwkeQg==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
       "dependencies": {
-        "playwright": "1.40.0"
+        "playwright": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -1134,10 +1170,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+      "dev": true
+    },
     "node_modules/@qavajs/cli": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@qavajs/cli/-/cli-0.32.0.tgz",
-      "integrity": "sha512-GY2Ezr73RZgdNclvwAN9kVSVslNdk6QDf45KfxpvJV3n7dHriJbslt0hTUq7IHtji+DEKHfHeP73+MO0EnaifA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@qavajs/cli/-/cli-0.32.1.tgz",
+      "integrity": "sha512-GsOxcjrc04wW8I2aUCE9SRV7tnOkgh5S+OwyFoD47cAmfRcjMgupaw/UxgdhfcnF/pzTCXZSvO0GJS96pVjd3A==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -1499,6 +1541,27 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vitest/ui": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.34.6.tgz",
+      "integrity": "sha512-/fxnCwGC0Txmr3tF3BwAbo3v6U2SkBTGR9UB8zo0Ztlx0BTOXHucE0gDHY7SjwEktCOHatiGmli9kZD6gYSoWQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "0.34.6",
+        "fast-glob": "^3.3.0",
+        "fflate": "^0.8.0",
+        "flatted": "^3.2.7",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.30.1 <1"
+      }
+    },
     "node_modules/@vitest/utils": {
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
@@ -1744,6 +1807,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -2656,6 +2731,31 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2664,6 +2764,12 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "dev": true
     },
     "node_modules/figures": {
       "version": "3.2.0",
@@ -2708,6 +2814,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -2755,6 +2873,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "dev": true
     },
     "node_modules/foreground-child": {
       "version": "3.1.1",
@@ -2906,6 +3030,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/global-agent": {
@@ -3251,6 +3387,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3258,6 +3403,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-installed-globally": {
@@ -3283,6 +3440,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-path-inside": {
@@ -3728,6 +3894,15 @@
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -3735,6 +3910,19 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
       }
     },
     "node_modules/mime": {
@@ -3843,6 +4031,15 @@
         "pathe": "^1.1.1",
         "pkg-types": "^1.0.3",
         "ufo": "^1.3.0"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -4237,6 +4434,18 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -4279,11 +4488,11 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
-      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "dependencies": {
-        "playwright-core": "1.40.0"
+        "playwright-core": "1.40.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -4296,9 +4505,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
-      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ==",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -4426,6 +4635,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
@@ -4654,6 +4883,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -4710,6 +4949,29 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
@@ -4916,6 +5178,20 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/sirv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -5250,6 +5526,18 @@
         "node": ">=8.17.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -5264,6 +5552,15 @@
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
       "dev": true
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.1",
@@ -6716,6 +7013,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6724,17 +7047,23 @@
       "optional": true
     },
     "@playwright/test": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.0.tgz",
-      "integrity": "sha512-PdW+kn4eV99iP5gxWNSDQCbhMaDVej+RXL5xr6t04nbKLCBwYtA046t7ofoczHOm8u6c+45hpDKQVZqtqwkeQg==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.40.1.tgz",
+      "integrity": "sha512-EaaawMTOeEItCRvfmkI9v6rBkF1svM8wjl/YPRrg2N2Wmp+4qJYkWtJsbew1szfKKDm6fPLy4YAanBhIlf9dWw==",
       "requires": {
-        "playwright": "1.40.0"
+        "playwright": "1.40.1"
       }
     },
+    "@polka/url": {
+      "version": "1.0.0-next.23",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.23.tgz",
+      "integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
+      "dev": true
+    },
     "@qavajs/cli": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@qavajs/cli/-/cli-0.32.0.tgz",
-      "integrity": "sha512-GY2Ezr73RZgdNclvwAN9kVSVslNdk6QDf45KfxpvJV3n7dHriJbslt0hTUq7IHtji+DEKHfHeP73+MO0EnaifA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@qavajs/cli/-/cli-0.32.1.tgz",
+      "integrity": "sha512-GsOxcjrc04wW8I2aUCE9SRV7tnOkgh5S+OwyFoD47cAmfRcjMgupaw/UxgdhfcnF/pzTCXZSvO0GJS96pVjd3A==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -7056,6 +7385,21 @@
         "tinyspy": "^2.1.1"
       }
     },
+    "@vitest/ui": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-0.34.6.tgz",
+      "integrity": "sha512-/fxnCwGC0Txmr3tF3BwAbo3v6U2SkBTGR9UB8zo0Ztlx0BTOXHucE0gDHY7SjwEktCOHatiGmli9kZD6gYSoWQ==",
+      "dev": true,
+      "requires": {
+        "@vitest/utils": "0.34.6",
+        "fast-glob": "^3.3.0",
+        "fflate": "^0.8.0",
+        "flatted": "^3.2.7",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3"
+      }
+    },
     "@vitest/utils": {
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
@@ -7245,6 +7589,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "buffer": {
@@ -7945,6 +8298,28 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      }
+    },
+    "fastq": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -7953,6 +8328,12 @@
       "requires": {
         "pend": "~1.2.0"
       }
+    },
+    "fflate": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
+      "integrity": "sha512-/exOvEuc+/iaUm105QIiOt4LpBdMTWsXxqR0HDF35vx3fmaKzw7354gTilCh5rkzEt8WYyG//ku3h3nRmd7CHQ==",
+      "dev": true
     },
     "figures": {
       "version": "3.2.0",
@@ -7990,6 +8371,15 @@
             "brace-expansion": "^2.0.1"
           }
         }
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
       }
     },
     "finalhandler": {
@@ -8033,6 +8423,12 @@
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
       }
+    },
+    "flatted": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "dev": true
     },
     "foreground-child": {
       "version": "3.1.1",
@@ -8137,6 +8533,15 @@
         "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "global-agent": {
@@ -8395,11 +8800,26 @@
         "has": "^1.0.3"
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
     },
     "is-installed-globally": {
       "version": "0.4.0",
@@ -8415,6 +8835,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
       "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
     "is-path-inside": {
@@ -8763,11 +9189,27 @@
       "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      }
     },
     "mime": {
       "version": "1.6.0",
@@ -8840,6 +9282,12 @@
         "pkg-types": "^1.0.3",
         "ufo": "^1.3.0"
       }
+    },
+    "mrmime": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
+      "integrity": "sha512-hzzEagAgDyoU1Q6yg5uI+AorQgdvMCur3FcKf7NhMKWsaYg+RnbTyHRa/9IlLF9rf455MOCtcqqrQQ83pPP7Uw==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",
@@ -9131,6 +9579,12 @@
       "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
+    "picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -9164,18 +9618,18 @@
       }
     },
     "playwright": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.0.tgz",
-      "integrity": "sha512-gyHAgQjiDf1m34Xpwzaqb76KgfzYrhK7iih+2IzcOCoZWr/8ZqmdBw+t0RU85ZmfJMgtgAiNtBQ/KS2325INXw==",
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.40.1.tgz",
+      "integrity": "sha512-2eHI7IioIpQ0bS1Ovg/HszsN/XKNwEG1kbzSDDmADpclKc7CyqkHw7Mg2JCz/bbCxg25QUPcjksoMW7JcIFQmw==",
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.40.0"
+        "playwright-core": "1.40.1"
       }
     },
     "playwright-core": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.0.tgz",
-      "integrity": "sha512-fvKewVJpGeca8t0ipM56jkVSU6Eo0RmFvQ/MaCQNDYm+sdvKkMBBWTE1FdeMqIdumRaXXjZChWHvIzCGM/tA/Q=="
+      "version": "1.40.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.40.1.tgz",
+      "integrity": "sha512-+hkOycxPiV534c4HhpfX6yrlawqVUzITRKwHAmYfmsVreltEl6fAZJ3DPfLMOODw0H3s1Itd6MDCWmP1fl/QvQ=="
     },
     "postcss": {
       "version": "8.4.31",
@@ -9258,6 +9712,12 @@
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "5.1.1",
@@ -9431,6 +9891,12 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -9469,6 +9935,15 @@
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
       "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
       "dev": true
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "rxjs": {
       "version": "7.8.1",
@@ -9633,6 +10108,17 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "sirv": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.3.tgz",
+      "integrity": "sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==",
+      "dev": true,
+      "requires": {
+        "@polka/url": "^1.0.0-next.20",
+        "mrmime": "^1.0.0",
+        "totalist": "^3.0.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",
@@ -9903,6 +10389,15 @@
         "rimraf": "^3.0.0"
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -9913,6 +10408,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
       "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "dev": true
+    },
+    "totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
       "dev": true
     },
     "ts-node": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qavajs/steps-playwright",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "steps to interact with playwright",
   "main": "./index.js",
   "scripts": {
@@ -8,6 +8,7 @@
     "test": "vitest --coverage run",
     "install:browsers": "playwright install",
     "test:e2e": "qavajs run --config test-e2e/webui.ts",
+    "test:e2e:electron": "qavajs run --config test-e2e/webui.ts --profile electron",
     "debug:e2e:electron": "qavajs run --config test-e2e/webui.ts --profile electron",
     "debug:e2e": "qavajs run --config test-e2e/webui.ts --profile debug"
   },
@@ -26,7 +27,7 @@
   "homepage": "https://github.com/qavajs/steps-playwright#readme",
   "devDependencies": {
     "@cucumber/cucumber": "^10.0.1",
-    "@qavajs/cli": "^0.32.0",
+    "@qavajs/cli": "^0.32.1",
     "@qavajs/console-formatter": "^0.6.0",
     "@qavajs/html-formatter": "^0.15.2",
     "@qavajs/memory": "^1.6.2",
@@ -35,6 +36,7 @@
     "@types/chai": "^4.3.11",
     "@types/express": "^4.17.21",
     "@vitest/coverage-v8": "^0.34.6",
+    "@vitest/ui": "^0.34.6",
     "electron": "^27.1.2",
     "express": "^4.18.2",
     "ts-node": "^10.9.1",
@@ -42,8 +44,8 @@
     "vitest": "^0.34.6"
   },
   "dependencies": {
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.40.1",
     "@qavajs/validation": "^0.7.0",
-    "playwright": "^1.40.0"
+    "playwright": "^1.40.1"
   }
 }

--- a/src/browserManager.ts
+++ b/src/browserManager.ts
@@ -1,0 +1,153 @@
+import { driverProvider } from './driverProvider';
+import { Browser, BrowserContext, ElectronApplication, Page } from 'playwright';
+
+type BrowserDict = {
+    [key: string]: Browser;
+}
+
+interface NamedContext extends BrowserContext {
+    name?: string;
+}
+
+export class BrowserManager {
+    public drivers: BrowserDict = {};
+    public driver?: Browser;
+    public context?: NamedContext;
+    public page?: Page;
+    private readonly driverProvider: (config: any) => Promise<Browser>;
+
+    constructor(driverProvider: (config: any) => Promise<Browser>) {
+        this.driverProvider = driverProvider;
+    }
+    async launchDriver(key: string, driverConfig: any) {
+        const driverInstance = (key === 'default' && this.drivers.default)
+            ? this.drivers.default
+            : await this.driverProvider(driverConfig);
+        this.drivers[key] = driverInstance;
+        this.setDriver(driverInstance);
+        if (driverConfig.isElectron) {
+            this.setContext((driverInstance as any as ElectronApplication).context());
+            this.setPage(await (driverInstance as any as ElectronApplication).firstWindow())
+        } else {
+            const context = await driverInstance.newContext(driverConfig);
+            this.setContext(context);
+            this.setPage(await context.newPage());
+        }
+        (this.context as NamedContext).name = 'default';
+    }
+
+    async launchContext(key: string, contextConfig: any) {
+        if (!this.driver) throw new Error('No active drivers launched');
+        const newContext: NamedContext = await driver.newContext(contextConfig);
+        newContext.name = key;
+        const newPage = await newContext.newPage();
+        this.setContext(newContext);
+        this.setPage(newPage);
+    }
+
+    async switchDriver(key: string) {
+        const currentDriver = this.drivers[key];
+        if (!currentDriver) throw new Error(`Driver '${key}' was not found`);
+        this.setDriver(currentDriver);
+        this.setContext(this.getDefaultContext());
+        this.setPage(await this.getFirstPage());
+    }
+
+    async switchContext(key: string) {
+        const currentContext = this.findContext(key);
+        this.setContext(currentContext);
+        this.setPage(await this.getFirstPage());
+    }
+
+    async closeContext(key: string) {
+        const currentContext = this.findContext(key);
+        await currentContext.close();
+        if (this.context === currentContext) {
+            this.setContext(this.getDefaultContext());
+            this.setPage(await this.getFirstPage());
+        }
+    }
+
+    findContext(key: string) {
+        const currentContext = this.driver?.contexts().find((ctx: NamedContext) => ctx.name === key);
+        if (!currentContext) throw new Error(`Context '${key}' was not found`);
+        return currentContext;
+    }
+    async closeDriver(driverKey: string) {
+        const currentDriver = this.drivers[driverKey];
+        if (!currentDriver) throw new Error(`Driver '${driverKey}' was not found`);
+        await currentDriver.close();
+        delete this.drivers[driverKey];
+        if (this.driver === currentDriver) {
+            this.setDriver(this.drivers['default']);
+            this.setContext(this.getDefaultContext());
+            this.setPage(await this.getFirstPage());
+        }
+    }
+
+    /**
+     * return to default state (1 browser, no contexts)
+     */
+    async teardown() {
+        for (const driverKey in this.drivers) {
+            const driverInstance = this.drivers[driverKey] as any;
+            if (driverInstance.firstWindow) {
+                await this.electronTeardown(driverInstance, driverKey);
+            } else {
+                await this.browserTeardown(driverInstance, driverKey);
+            }
+        }
+        this.driver = this.drivers['default'];
+    }
+
+    async browserTeardown(driverInstance: Browser, driverKey: string) {
+        if (driverKey !== 'default') {
+            await driverInstance.close();
+            delete this.drivers[driverKey];
+        } else {
+            const contexts = driverInstance.contexts() as BrowserContext[];
+            for (const ctx of contexts) {
+                await ctx.close();
+            }
+        }
+    }
+
+    async electronTeardown(driverInstance: ElectronApplication, driverKey: string) {
+        await driverInstance.evaluate((main: any) => { main.app.exit(0) });
+        delete this.drivers[driverKey];
+    }
+
+    async close() {
+        for (const driverKey in this.drivers) {
+            const driverInstance = this.drivers[driverKey] as any;
+            await driverInstance.close();
+            delete this.drivers[driverKey];
+        }
+    };
+
+    getDefaultContext(): BrowserContext {
+        const currentDriver: any = this.driver;
+        return currentDriver.context ? currentDriver.context() : currentDriver.contexts()[0];
+    }
+
+    async getFirstPage(): Promise<Page> {
+        const currentDriver: any = this.driver;
+        const currentContext: any = this.context;
+        return currentDriver.firstWindow ? currentDriver.firstWindow() : currentContext.pages()[0];
+    }
+
+    setDriver(driver: any) {
+        this.driver = global.browser = global.driver = driver;
+    }
+
+    setContext(context: any) {
+        this.context = global.context = context;
+    }
+
+    setPage(page: any) {
+        this.page = global.page = page;
+    }
+
+}
+
+export default new BrowserManager(driverProvider);

--- a/src/multiBrowser.ts
+++ b/src/multiBrowser.ts
@@ -1,4 +1,50 @@
 import { When } from '@cucumber/cucumber';
+import browserManager from './browserManager';
+import { getValue } from './transformers';
+
+/**
+ * Launch new driver
+ * @param {string} driverName - driver name
+ * @example
+ * When I launch new driver as 'browser2'
+ */
+When('I launch new driver as {string}', async function (driverName: string) {
+    await browserManager.launchDriver(driverName, config?.driverConfig);
+});
+
+/**
+ * Open new driver with provided config
+ * @param {string} driverName - driver name
+ * @param {string} config - json with browser config
+ * @example
+ * When I launch new driver as 'browser2'
+ */
+When('I launch new driver as {string}:', async function (driverName: string, rawConfig: string) {
+    const config = await getValue(rawConfig);
+    await browserManager.launchDriver(driverName, JSON.parse(config));
+});
+
+/**
+ * Switch to driver
+ * @param {string} driverName - driver name
+ * @example
+ * When I launch new driver as 'browser2'
+ * And I switch to 'browser2' driver
+ * And I switch to 'default' driver
+ */
+When('I switch to {string} driver', async function (driverName: string) {
+    await browserManager.switchDriver(driverName);
+});
+
+/**
+ * Close driver
+ * @param {string} driverName - driver name
+ * @example
+ * When I close to 'browser2' driver
+ */
+When('I close {string} driver', async function (driverName: string) {
+    await browserManager.closeDriver(driverName);
+});
 
 /**
  * Open new browser context
@@ -7,13 +53,7 @@ import { When } from '@cucumber/cucumber';
  * When I open new browser context as 'browser2'
  */
 When('I open new browser context as {string}', async function (browserContextName: string) {
-    if (!global.contexts) {
-        global.contexts = {};
-        global.contexts.default = global.context;
-    }
-    const newContext= await global.browser.newContext(config?.driverConfig?.capabilities);
-    await newContext.newPage();
-    global.contexts[browserContextName] = newContext;
+    await browserManager.launchContext(browserContextName, config?.driverConfig);
 });
 
 /**
@@ -25,27 +65,17 @@ When('I open new browser context as {string}', async function (browserContextNam
  * And I switch to 'default' browser context
  */
 When('I switch to {string} browser context', async function (browserContextName: string) {
-    if (!global.contexts) throw new Error('No other browser context launched');
-    const targetContext = global.contexts[browserContextName];
-    if (!targetContext) throw new Error(`'${browserContextName}' context is not defined`);
-    global.context = targetContext;
-    global.page = targetContext.pages()[0];
+    await browserManager.switchContext(browserContextName);
 });
 
 /**
- * Close to browser context
+ * Close browser context
  * @param {string} browserContextName - browser context name
  * @example
  * When I close to 'browser2' browser context
  */
 When('I close {string} browser context', async function (browserContextName: string) {
-    if (!global.contexts) throw new Error('No other browser context launched');
-    const targetContext = global.contexts[browserContextName];
-    if (!targetContext) throw new Error(`'${browserContextName}' context is not defined`);
-    await targetContext.close();
-    global.context = global.contexts.default;
-    global.page = context.pages()[0];
-    delete global.contexts[browserContextName];
+    await browserManager.closeContext(browserContextName);
 });
 
 

--- a/test-e2e/features/electron/electron.feature
+++ b/test-e2e/features/electron/electron.feature
@@ -4,3 +4,21 @@ Feature: electron
     * I click 'Open New Window Electron Button'
     * I switch to 'qavajs electron app new window' window
     * I click 'Close Current Window Electron Button'
+
+  Scenario: open electron and browser
+    * I click 'Open New Window Electron Button'
+    * I switch to 'qavajs electron app new window' window
+    When I launch new driver as 'browser2':
+    """
+    {
+      "capabilities": {
+          "browserName": "chromium",
+          "headless": false
+      }
+    }
+    """
+    And I switch to 'browser2' driver
+    And I open '$valuesPage' url
+    Then I expect current url to contain 'values.html'
+    And I switch to 'default' driver
+    * I click 'Close Current Window Electron Button'

--- a/test-e2e/features/multiBrowser.feature
+++ b/test-e2e/features/multiBrowser.feature
@@ -14,3 +14,34 @@ Feature: multiBrowser
     Then I expect current url to contain 'values.html'
     When I close 'browser2' browser context
     Then I expect current url to contain 'actions.html'
+
+  Scenario: new browser
+    Then I expect current url to contain 'actions.html'
+    When I launch new driver as 'browser2'
+    And I switch to 'browser2' driver
+    And I open '$valuesPage' url
+    And I switch to 'default' driver
+    Then I expect current url to contain 'actions.html'
+    When I switch to 'browser2' driver
+    Then I expect current url to contain 'values.html'
+    When I close 'browser2' driver
+    Then I expect current url to contain 'actions.html'
+
+  Scenario: new browser with provided config
+    Then I expect current url to contain 'actions.html'
+    When I launch new driver as 'browser2':
+    """
+    {
+      "capabilities": {
+          "browserName": "firefox"
+      }
+    }
+    """
+    And I switch to 'browser2' driver
+    And I open '$valuesPage' url
+    And I switch to 'default' driver
+    Then I expect current url to contain 'actions.html'
+    When I switch to 'browser2' driver
+    Then I expect current url to contain 'values.html'
+    When I close 'browser2' driver
+    Then I expect current url to contain 'actions.html'

--- a/test-e2e/webui.ts
+++ b/test-e2e/webui.ts
@@ -77,7 +77,7 @@ export const electron = {
     ...common,
     paths: ['test-e2e/features/electron/*.feature'],
     retry: 0,
-    tags: '@debug',
+    // tags: '@debug',
     browser: {
         logLevel: 'warn',
         timeout: {
@@ -88,5 +88,6 @@ export const electron = {
             args: ['test-e2e/apps/electron/main.js'],
             headless: false
         }
-    }
+    },
+    parallel: 1
 }

--- a/test/browserManager.spec.ts
+++ b/test/browserManager.spec.ts
@@ -1,0 +1,303 @@
+import { describe, test, expect } from 'vitest';
+import { BrowserManager } from '../src/browserManager';
+
+declare global {
+    var browser: any
+    var driver: any;
+    var context: any;
+    var page: any;
+    var config: any;
+}
+
+class Page {
+    isClosed = false;
+    async close() {
+        this.isClosed = true;
+    }
+}
+
+class Context {
+    _pages: Page[] = [];
+    isClosed = false;
+    async close() {
+        this.isClosed = true;
+    }
+
+    async newPage() {
+        const page = new Page();
+        this._pages.push(page);
+        return page;
+    }
+
+    pages() {
+        return this._pages;
+    }
+}
+
+class Driver {
+    _contexts: Context[] = [];
+    isClosed = false;
+    async close() {
+        this.isClosed = true;
+    }
+}
+
+class Browser extends Driver {
+    async newContext() {
+        const context = new Context();
+        this._contexts.push(context);
+        return context;
+    }
+
+    contexts() {
+        return this._contexts
+    }
+}
+
+class ElectronApplication extends Driver {
+    constructor() {
+        super();
+        const context = new Context();
+        this._contexts.push(context);
+        context._pages.push(new Page());
+    }
+
+    context() {
+        return this._contexts[0];
+    }
+
+    async firstWindow() {
+        return this._contexts[0]._pages[0]
+    }
+
+    async evaluate() {}
+}
+
+function driverProvider(config: any) {
+    if (config.browserName === 'electron') return new ElectronApplication();
+    return new Browser();
+}
+
+describe('launch driver', () => {
+    test('launch first browser', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        expect(global.browser).toBeInstanceOf(Browser);
+        expect(global.context).toBeInstanceOf(Context);
+        expect(global.page).toBeInstanceOf(Page);
+        expect(global.browser.isClosed).toBe(false);
+        expect(global.context.isClosed).toBe(false);
+        expect(global.page.isClosed).toBe(false);
+        expect(browserManager.drivers.default).toBeInstanceOf(Browser);
+        expect((browserManager.drivers.default as any).isClosed).toBe(false);
+    });
+
+    test('launch first electron', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'electron', isElectron: true });
+        expect(global.browser).toBeInstanceOf(ElectronApplication);
+        expect(global.context).toBeInstanceOf(Context);
+        expect(global.page).toBeInstanceOf(Page);
+        expect(global.browser.isClosed).toBe(false);
+        expect(global.context.isClosed).toBe(false);
+        expect(global.page.isClosed).toBe(false);
+        expect(browserManager.drivers.default).toBeInstanceOf(ElectronApplication);
+        expect((browserManager.drivers.default as any).isClosed).toBe(false);
+    });
+
+    test('launch two browsers', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('second', { browserName: 'chrome', isElectron: false });
+        expect(browserManager.drivers.default).toBeInstanceOf(Browser);
+        expect(browserManager.drivers.second).toBeInstanceOf(Browser);
+        expect((browserManager.drivers.default as any).isClosed).toBe(false);
+        expect((browserManager.drivers.second as any).isClosed).toBe(false);
+    });
+
+    test('launch electron and browser', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'electron', isElectron: true });
+        await browserManager.launchDriver('second', { browserName: 'chrome', isElectron: false });
+        expect(browserManager.drivers.default).toBeInstanceOf(ElectronApplication);
+        expect(browserManager.drivers.second).toBeInstanceOf(Browser);
+        expect((browserManager.drivers.default as any).isClosed).toBe(false);
+        expect((browserManager.drivers.second as any).isClosed).toBe(false);
+    });
+
+    test('relaunch default browser', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        const defaultBrowser = browserManager.drivers.default;
+        expect(defaultBrowser).toBeInstanceOf(Browser);
+        await browserManager.teardown();
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        const relaunchedBrowser = browserManager.drivers.default;
+        expect(relaunchedBrowser).toBeInstanceOf(Browser);
+        expect(relaunchedBrowser).toBe(defaultBrowser);
+    });
+});
+
+describe('context', () => {
+    test('launch new context', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', {browserName: 'chrome', isElectron: false});
+        const defaultBrowser = browserManager.drivers.default;
+        await browserManager.launchContext('newContext',{});
+        expect(global.context).toBe(defaultBrowser.contexts()[1]);
+    });
+
+    test('switch context', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', {browserName: 'chrome', isElectron: false});
+        const defaultBrowser = browserManager.drivers.default;
+        await browserManager.launchContext('newContext',{});
+        expect(global.context).toBe(defaultBrowser.contexts()[1]);
+        expect(global.page).toBe(defaultBrowser.contexts()[1].pages()[0]);
+        await browserManager.switchContext('default');
+        expect(global.context).toBe(defaultBrowser.contexts()[0]);
+        expect(global.page).toBe(defaultBrowser.contexts()[0].pages()[0]);
+    });
+
+    test('close current context', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', {browserName: 'chrome', isElectron: false});
+        const defaultBrowser = browserManager.drivers.default;
+        await browserManager.launchContext('newContext',{});
+        await browserManager.launchContext('newContext2',{});
+        expect(global.context).toBe(defaultBrowser.contexts()[2]);
+        expect(global.page).toBe(defaultBrowser.contexts()[2].pages()[0]);
+        await browserManager.closeContext('newContext2');
+        expect(global.context).toBe(defaultBrowser.contexts()[0]);
+        expect(global.page).toBe(defaultBrowser.contexts()[0].pages()[0]);
+    });
+
+    test('close other context', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', {browserName: 'chrome', isElectron: false});
+        const defaultBrowser = browserManager.drivers.default;
+        await browserManager.launchContext('newContext',{});
+        await browserManager.launchContext('newContext2',{});
+        expect(global.context).toBe(defaultBrowser.contexts()[2]);
+        expect(global.page).toBe(defaultBrowser.contexts()[2].pages()[0]);
+        await browserManager.closeContext('newContext');
+        expect(global.context).toBe(defaultBrowser.contexts()[2]);
+        expect(global.page).toBe(defaultBrowser.contexts()[2].pages()[0]);
+    });
+
+    test('launch new context if not driver launched', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        expect(() => browserManager.launchContext('newContext',{})).rejects.toThrow('No active drivers launched')
+    });
+
+    test('switch to not existing context', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        expect(() => browserManager.switchContext('context2')).rejects.toThrow(`Context 'context2' was not found`)
+    });
+
+});
+
+describe('switch driver', () => {
+    test('switch to other browser', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('second', { browserName: 'chrome', isElectron: false });
+        await browserManager.switchDriver('second');
+        const expectedBrowser = browserManager.drivers.second as any;
+        expect(global.browser).toBe(expectedBrowser);
+        const expectedContext = expectedBrowser._contexts[0];
+        expect(global.context).toBe(expectedContext);
+        expect(global.page).toBe(expectedContext._pages[0]);
+    });
+
+    test('switch to electron', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'electron', isElectron: true });
+        await browserManager.launchDriver('chrome', { browserName: 'chrome', isElectron: false });
+        await browserManager.switchDriver('chrome');
+        const chrome = browserManager.drivers.chrome as any;
+        expect(global.browser).toBe(chrome);
+        const chromeDefaultContext = chrome._contexts[0];
+        expect(global.context).toBe(chromeDefaultContext);
+        expect(global.page).toBe(chromeDefaultContext._pages[0]);
+
+        await browserManager.switchDriver('default');
+        const electron = browserManager.drivers.default as any;
+        expect(global.browser).toBe(electron);
+        const electronContext = electron._contexts[0];
+        expect(global.context).toBe(electronContext);
+        expect(global.page).toBe(electronContext._pages[0]);
+    });
+
+    test('switch to not existing driver', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        expect(() => browserManager.switchDriver('chrome')).rejects.toThrow(`Driver 'chrome' was not found`)
+    });
+
+});
+
+describe('teardown', () => {
+    test('single browser', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        await browserManager.teardown();
+        const expectedBrowser = browserManager.drivers.default as any;
+        expect(global.browser).toBe(expectedBrowser);
+    });
+
+    test('single electron', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'electron', isElectron: true });
+        await browserManager.teardown();
+        expect(browserManager.drivers.default).toBe(undefined);
+    });
+
+    test('electron and browser', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'electron', isElectron: true });
+        await browserManager.launchDriver('chrome', { browserName: 'chrome', isElectron: false });
+        await browserManager.teardown();
+        expect(browserManager.drivers.default).toBe(undefined);
+        expect(browserManager.drivers.chrome).toBe(undefined);
+    });
+
+    test('close current driver', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('chrome1', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('chrome2', { browserName: 'chrome', isElectron: false });
+        expect(global.browser).toBe(browserManager.drivers.chrome2);
+        await browserManager.closeDriver('chrome2')
+        expect(global.browser).toBe(browserManager.drivers.default);
+        expect(browserManager.drivers.chrome2).toBe(undefined);
+    });
+
+    test('close other driver', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('chrome1', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('chrome2', { browserName: 'chrome', isElectron: false });
+        expect(global.browser).toBe(browserManager.drivers.chrome2);
+        await browserManager.closeDriver('chrome1')
+        expect(global.browser).toBe(browserManager.drivers.chrome2);
+        expect(browserManager.drivers.chrome1).toBe(undefined);
+    });
+
+    test('close all drivers', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('chrome1', { browserName: 'chrome', isElectron: false });
+        await browserManager.launchDriver('chrome2', { browserName: 'chrome', isElectron: false });
+        await browserManager.close();
+        expect(browserManager.drivers).toEqual({});
+    });
+
+    test('close not existing driver', async () => {
+        const browserManager = new BrowserManager(driverProvider as any);
+        await browserManager.launchDriver('default', { browserName: 'chrome', isElectron: false });
+        expect(() => browserManager.closeDriver('chrome')).rejects.toThrow(`Driver 'chrome' was not found`)
+    });
+
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ["src/**/*.ts"],
-      exclude: ["/lib/", "/node_modules/"],
+      exclude: ["/lib/", "/node_modules/", "src/driverProvider.ts"],
       branches: 80,
       functions: 90,
       lines: 90,


### PR DESCRIPTION
- :rocket: introduced browserManager object to control all launched browsersrowser and electron instances
- :rocket: added steps to start/stop/switch to other browser/electron instances

Before submitting this PR, please ensure that you have completed the following:

- [x] Updated the CHANGELOG.md.
- [x] Checked that there aren't other open pull requests for the same issue/update.
- [x] Checked that your contribution follows the project's contribution guidelines.
- [x] Added corresponding unit/E2E tests
- [x] Unit and E2E pass

## Motivation

Need to have a holistic approach to launch/control/stop multiple instances of browsers/electron applications/contexts across the framework
